### PR TITLE
Patches to support test programming with ST-LINK_CLI.EXE

### DIFF
--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -44,7 +44,10 @@ LOCAL_MOCKS_DATABASE = join(user_data_dir("mbedls"), "mock.json")
 
 ST_BOARDS = {
     u'0744': u'NUCLEO_F410RB',
-    u'0745': u'NUCLEO_F303RE'
+    u'0745': u'NUCLEO_F303RE',
+    u'0730': u'NUCLEO_F072RB',
+    u'0760': u'NUCLEO_L073RZ',
+    u'0740': u'NUCLEO_F411RE'
 }
 
 DEFAULT_PLATFORM_DB = {
@@ -124,16 +127,13 @@ DEFAULT_PLATFORM_DB = {
         u'0715': u'NUCLEO_L053R8',
         u'0720': u'NUCLEO_F401RE',
         u'0725': u'NUCLEO_F030R8',
-        u'0730': u'NUCLEO_F072RB',
         u'0735': u'NUCLEO_F334R8',
-        u'0740': u'NUCLEO_F411RE',
         u'0742': u'NUCLEO_F413ZH',
         u'0743': u'DISCO_F413ZH',
         u'0746': u'DISCO_F303VC',
         u'0747': u'NUCLEO_F303ZE',
         u'0750': u'NUCLEO_F091RC',
         u'0755': u'NUCLEO_F070RB',
-        u'0760': u'NUCLEO_L073RZ',
         u'0764': u'DISCO_L475VG_IOT01A',
         u'0765': u'NUCLEO_L476RG',
         u'0766': u'SILICA_SENSOR_NODE',

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -320,7 +320,7 @@ DEFAULT_PLATFORM_DB = {
         u'C035': u'UBLOX_C030_R3121',
         u'FFFF': u'K20 BOOTLOADER',
         u'RIOT': u'RIOT',
-    }.update(ST_BOARDS),
+    },
     u'jlink': {
         u'X729475D28G': {
             u'platform_name': u'NRF51_DK',
@@ -347,7 +347,7 @@ DEFAULT_PLATFORM_DB = {
         u'2241': 'SAML21J18A'
     }
 }
-
+DEFAULT_PLATFORM_DB['daplink'].update(ST_BOARDS)
 
 def _get_modified_time(path):
     try:

--- a/mbed_lstools/platform_database.py
+++ b/mbed_lstools/platform_database.py
@@ -42,7 +42,13 @@ del logging
 LOCAL_PLATFORM_DATABASE = join(user_data_dir("mbedls"), "platforms.json")
 LOCAL_MOCKS_DATABASE = join(user_data_dir("mbedls"), "mock.json")
 
+ST_BOARDS = {
+    u'0744': u'NUCLEO_F410RB',
+    u'0745': u'NUCLEO_F303RE'
+}
+
 DEFAULT_PLATFORM_DB = {
+    u'stlink': ST_BOARDS,
     u'daplink': {
         u'0001': u'LPC2368',
         u'0002': u'LPC2368',
@@ -123,8 +129,6 @@ DEFAULT_PLATFORM_DB = {
         u'0740': u'NUCLEO_F411RE',
         u'0742': u'NUCLEO_F413ZH',
         u'0743': u'DISCO_F413ZH',
-        u'0744': u'NUCLEO_F410RB',
-        u'0745': u'NUCLEO_F303RE',
         u'0746': u'DISCO_F303VC',
         u'0747': u'NUCLEO_F303ZE',
         u'0750': u'NUCLEO_F091RC',
@@ -316,7 +320,7 @@ DEFAULT_PLATFORM_DB = {
         u'C035': u'UBLOX_C030_R3121',
         u'FFFF': u'K20 BOOTLOADER',
         u'RIOT': u'RIOT',
-    },
+    }.update(ST_BOARDS),
     u'jlink': {
         u'X729475D28G': {
             u'platform_name': u'NRF51_DK',

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname), encoding="utf8").read()
 
 setup(name='mbed-ls',
-      version='1.6.2',
+      version='1.6.2-1',
       description=DESCRIPTION,
       long_description=read('README.md'),
       author=OWNER_NAMES,


### PR DESCRIPTION
**mbed-flasher** expects to find boards under "stlink" section in the platform database to allow flashing them with `ST-LINK_CLI.EXE`.